### PR TITLE
Remove unused variables

### DIFF
--- a/src/main/java/org/pac4j/javalin/CallbackHandler.java
+++ b/src/main/java/org/pac4j/javalin/CallbackHandler.java
@@ -14,7 +14,6 @@ import org.pac4j.core.util.FindBest;
 import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
 public class CallbackHandler implements Handler {
-    public CallbackLogic callbackLogic;
     public Config config;
     public String defaultUrl;
     public Boolean renewSession;
@@ -28,6 +27,7 @@ public class CallbackHandler implements Handler {
     }
 
     public CallbackHandler(Config config, String defaultUrl, Boolean renewSession) {
+        assertNotNull("config", config);
         this.config = config;
         this.defaultUrl = defaultUrl;
         this.renewSession = renewSession;
@@ -37,9 +37,7 @@ public class CallbackHandler implements Handler {
     public void handle(@NotNull Context javalinCtx) {
         final SessionStore bestSessionStore = FindBest.sessionStore(null, config, JEESessionStore.INSTANCE);
         final HttpActionAdapter bestAdapter = FindBest.httpActionAdapter(null, config, JavalinHttpActionAdapter.INSTANCE);
-        final CallbackLogic bestCallbackLogic = FindBest.callbackLogic(callbackLogic, config, DefaultCallbackLogic.INSTANCE);
-
-        assertNotNull("config", config);
+        final CallbackLogic bestCallbackLogic = FindBest.callbackLogic(null, config, DefaultCallbackLogic.INSTANCE);
 
         JavalinWebContext context = new JavalinWebContext(javalinCtx);
         bestCallbackLogic.perform(context,

--- a/src/main/java/org/pac4j/javalin/LogoutHandler.java
+++ b/src/main/java/org/pac4j/javalin/LogoutHandler.java
@@ -14,7 +14,6 @@ import org.pac4j.core.util.FindBest;
 import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
 public class LogoutHandler implements Handler {
-    public LogoutLogic logoutLogic;
     public Config config;
     public String defaultUrl;
     public String logoutUrlPattern;
@@ -31,6 +30,7 @@ public class LogoutHandler implements Handler {
     }
 
     public LogoutHandler(Config config, String defaultUrl, String logoutUrlPattern) {
+        assertNotNull("config", config);
         this.config = config;
         this.defaultUrl = defaultUrl;
         this.logoutUrlPattern = logoutUrlPattern;
@@ -40,9 +40,7 @@ public class LogoutHandler implements Handler {
     public void handle(@NotNull Context javalinCtx) {
         final SessionStore bestSessionStore = FindBest.sessionStore(null, config, JEESessionStore.INSTANCE);
         final HttpActionAdapter bestAdapter = FindBest.httpActionAdapter(null, config, JavalinHttpActionAdapter.INSTANCE);
-        final LogoutLogic bestLogic = FindBest.logoutLogic(logoutLogic, config, DefaultLogoutLogic.INSTANCE);
-
-        assertNotNull("config", config);
+        final LogoutLogic bestLogic = FindBest.logoutLogic(null, config, DefaultLogoutLogic.INSTANCE);
 
         bestLogic.perform(
             new JavalinWebContext(javalinCtx),

--- a/src/main/java/org/pac4j/javalin/SecurityHandler.java
+++ b/src/main/java/org/pac4j/javalin/SecurityHandler.java
@@ -17,7 +17,6 @@ import static org.pac4j.core.util.CommonHelper.assertNotNull;
 public class SecurityHandler implements Handler {
     private final String AUTH_GRANTED = "AUTH_GRANTED";
 
-    public SecurityLogic securityLogic;
     public Config config;
     public String clients;
     public String authorizers;
@@ -32,6 +31,7 @@ public class SecurityHandler implements Handler {
     }
 
     public SecurityHandler(Config config, String clients, String authorizers, String matchers) {
+        assertNotNull("config", config);
         this.config = config;
         this.clients = clients;
         this.authorizers = authorizers;
@@ -42,9 +42,7 @@ public class SecurityHandler implements Handler {
     public void handle(@NotNull Context javalinCtx) {
         final SessionStore bestSessionStore = FindBest.sessionStore(null, config, JEESessionStore.INSTANCE);
         final HttpActionAdapter bestAdapter = FindBest.httpActionAdapter(null, config, JavalinHttpActionAdapter.INSTANCE);
-        final SecurityLogic bestLogic = FindBest.securityLogic(securityLogic, config, DefaultSecurityLogic.INSTANCE);
-
-        assertNotNull("config", config);
+        final SecurityLogic bestLogic = FindBest.securityLogic(null, config, DefaultSecurityLogic.INSTANCE);
 
         JavalinWebContext context = new JavalinWebContext(javalinCtx);
         Object result = bestLogic.perform(


### PR DESCRIPTION
This removes some never set variables. The alternative is to set them via an additional ctor parameter, but apparently noone has needed that yet.

One more thing I saw while going through the code. All three handlers are trying to retrieve the session store, http action adapter and callback logic for **every** request (the snippet below). This could be done in the ctor as well, however it seems that the `config` is mutable, allowing to change it while running. Is that on purpose?

```java
final SessionStore bestSessionStore = FindBest.sessionStore(null, config, JEESessionStore.INSTANCE);
final HttpActionAdapter bestAdapter = FindBest.httpActionAdapter(null, config, JavalinHttpActionAdapter.INSTANCE);
final CallbackLogic bestCallbackLogic = FindBest.callbackLogic(null, config, DefaultCallbackLogic.INSTANCE);
```