### PR TITLE
Update to Javalin 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </developers>
 
     <properties>
-        <javalin.version>3.13.13</javalin.version>
+        <javalin.version>5.1.1</javalin.version>
         <pac4j.version>5.6.1</pac4j.version>
         <java.version>11</java.version>
     </properties>
@@ -66,12 +66,18 @@
         </dependency>
         <dependency>
             <groupId>org.pac4j</groupId>
-            <artifactId>pac4j-javaee</artifactId>
+            <artifactId>pac4j-jakartaee</artifactId>
             <version>${pac4j.version}</version>
         </dependency>
         <!-- - - - - - - - - - -->
         <!-- Test-dependencies -->
         <!-- - - - - - - - - - -->
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin-rendering</artifactId>
+            <version>${javalin.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>

--- a/src/main/java/org/pac4j/javalin/JavalinHttpActionAdapter.java
+++ b/src/main/java/org/pac4j/javalin/JavalinHttpActionAdapter.java
@@ -2,6 +2,8 @@ package org.pac4j.javalin;
 
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.ForbiddenResponse;
+import io.javalin.http.HttpStatus;
+import io.javalin.http.RedirectResponse;
 import io.javalin.http.UnauthorizedResponse;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
@@ -39,8 +41,8 @@ public class JavalinHttpActionAdapter implements HttpActionAdapter {
             context.getJavalinCtx().result(((WithContentAction) action).getContent());
             return null;
         } else if (action instanceof WithLocationAction) {
-            context.getJavalinCtx().redirect(((WithLocationAction) action).getLocation(), action.getCode());
-            return null;
+            context.getJavalinCtx().redirect(((WithLocationAction) action).getLocation(), HttpStatus.forStatus(action.getCode()));
+            throw new RedirectResponse();
         } else {
             context.getJavalinCtx().status(action.getCode());
             return null;

--- a/src/main/java/org/pac4j/javalin/JavalinWebContext.java
+++ b/src/main/java/org/pac4j/javalin/JavalinWebContext.java
@@ -11,7 +11,7 @@ public class JavalinWebContext extends JEEContext {
     private final Context javalinCtx;
 
     public JavalinWebContext(Context javalinCtx) {
-        super(javalinCtx.req, javalinCtx.res);
+        super(javalinCtx.req(), javalinCtx.res());
         this.javalinCtx = javalinCtx;
     }
 

--- a/src/test/java/org/pac4j/javalin/CallbackHandlerTest.java
+++ b/src/test/java/org/pac4j/javalin/CallbackHandlerTest.java
@@ -1,6 +1,8 @@
 package org.pac4j.javalin;
 
 import io.javalin.http.Context;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pac4j.core.config.Config;
@@ -11,27 +13,26 @@ import org.pac4j.core.http.adapter.HttpActionAdapter;
 import org.pac4j.http.client.indirect.FormClient;
 import org.pac4j.jee.context.session.JEESessionStore;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class CallbackHandlerTest {
 
     private final TestCallbackLogic testCallbackLogic = new TestCallbackLogic();
     private final HttpServletRequest req = mock(HttpServletRequest.class);
     private final HttpServletResponse res = mock(HttpServletResponse.class);
-    private final Context ctx = new Context(req, res, Collections.emptyMap());
+    private final Context ctx = mock(Context.class);
     private final FormClient formClient = new FormClient();
     private final Config config = new Config(formClient);
-    private final CallbackHandler handler = new CallbackHandler(config);
+    private final CallbackHandler handler = new CallbackHandler(config, "DefaultClient");
 
     @BeforeEach
     public void setCallbackLogic() {
         config.setCallbackLogic(testCallbackLogic);
         formClient.setCallbackUrl("http://example.org/callbackUrl");
+        when(ctx.res()).thenReturn(res);
+        when(ctx.req()).thenReturn(req);
     }
 
     @Test
@@ -85,7 +86,7 @@ public class CallbackHandlerTest {
     public void testCustomDefaultUrl() {
         final Config config = new Config(formClient);
         config.setCallbackLogic(testCallbackLogic);
-        final CallbackHandler handler = new CallbackHandler(config, "http://example.org", true);
+        final CallbackHandler handler = new CallbackHandler(config, "http://example.org",  true);
 
         handler.handle(ctx);
 

--- a/src/test/java/org/pac4j/javalin/JavalinHttpActionAdapterTest.java
+++ b/src/test/java/org/pac4j/javalin/JavalinHttpActionAdapterTest.java
@@ -3,9 +3,14 @@ package org.pac4j.javalin;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.ForbiddenResponse;
+import io.javalin.http.HttpStatus;
 import io.javalin.http.RedirectResponse;
 import io.javalin.http.UnauthorizedResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.pac4j.core.exception.http.BadRequestAction;
 import org.pac4j.core.exception.http.ForbiddenAction;
 import org.pac4j.core.exception.http.FoundAction;
@@ -14,24 +19,26 @@ import org.pac4j.core.exception.http.OkAction;
 import org.pac4j.core.exception.http.UnauthorizedAction;
 import org.pac4j.jee.context.JEEContext;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("PMD.TooManyStaticImports")
 class JavalinHttpActionAdapterTest {
 
-    private HttpServletRequest req = mock(HttpServletRequest.class);
-    private HttpServletResponse res = mock(HttpServletResponse.class);
-    private Context ctx = new Context(req, res, Collections.emptyMap());
-    private JavalinWebContext context = new JavalinWebContext(ctx);
+    private final HttpServletRequest req = mock(HttpServletRequest.class);
+    private final HttpServletResponse res = mock(HttpServletResponse.class);
+    private final Context ctx = mock(Context.class);
+    private JavalinWebContext context;
+
+    @BeforeEach
+    public void setupMocks() {
+        when(ctx.res()).thenReturn(res);
+        when(ctx.req()).thenReturn(req);
+        context = new JavalinWebContext(ctx);
+    }
 
     @Test
     public void testActionNotNull() {
@@ -56,8 +63,10 @@ class JavalinHttpActionAdapterTest {
     public void testAdapterWithContentAction() {
         JavalinHttpActionAdapter.INSTANCE.adapt(new OkAction("my-content"), context);
 
-        verify(res).setStatus(200);
-        assertThat(ctx.resultString()).isEqualTo("my-content");
+        verify(ctx).status(200);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(ctx).result(captor.capture());
+        assertThat(captor.getValue()).isEqualTo("my-content");
     }
 
     @Test
@@ -65,8 +74,9 @@ class JavalinHttpActionAdapterTest {
         assertThatThrownBy(() -> JavalinHttpActionAdapter.INSTANCE.adapt(new FoundAction("/redirect"), context))
                 .isExactlyInstanceOf(RedirectResponse.class);
 
-        verify(res).setHeader(eq("Location"), eq("/redirect"));
-        verify(res).setStatus(302);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(ctx).redirect(captor.capture(), eq(HttpStatus.FOUND));
+        assertThat(captor.getValue()).isEqualTo("/redirect");
     }
 
     @Test
@@ -91,6 +101,6 @@ class JavalinHttpActionAdapterTest {
     public void testAdapterAnyOtherStatus() {
         JavalinHttpActionAdapter.INSTANCE.adapt(new HttpAction(123) {}, context);
 
-        verify(res).setStatus(123);
+        verify(ctx).status(123);
     }
 }

--- a/src/test/java/org/pac4j/javalin/LogoutHandlerTest.java
+++ b/src/test/java/org/pac4j/javalin/LogoutHandlerTest.java
@@ -1,6 +1,8 @@
 package org.pac4j.javalin;
 
 import io.javalin.http.Context;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pac4j.core.config.Config;
@@ -11,12 +13,9 @@ import org.pac4j.core.http.adapter.HttpActionAdapter;
 import org.pac4j.http.client.indirect.FormClient;
 import org.pac4j.jee.context.session.JEESessionStore;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class LogoutHandlerTest {
 
@@ -26,11 +25,13 @@ public class LogoutHandlerTest {
     private final LogoutHandler handler = new LogoutHandler(config);
     private final HttpServletRequest req = mock(HttpServletRequest.class);
     private final HttpServletResponse res = mock(HttpServletResponse.class);
-    private final Context ctx = new Context(req, res, Collections.emptyMap());
+    private final Context ctx = mock(Context.class);
 
     @BeforeEach
     public void setCallbackLogic() {
         config.setLogoutLogic(logoutLogic);
+        when(ctx.res()).thenReturn(res);
+        when(ctx.req()).thenReturn(req);
     }
 
     @Test

--- a/src/test/java/org/pac4j/javalin/SecurityHandlerTest.java
+++ b/src/test/java/org/pac4j/javalin/SecurityHandlerTest.java
@@ -2,6 +2,8 @@ package org.pac4j.javalin;
 
 import io.javalin.http.Context;
 import io.javalin.http.UnauthorizedResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pac4j.core.config.Config;
@@ -13,13 +15,10 @@ import org.pac4j.core.http.adapter.HttpActionAdapter;
 import org.pac4j.http.client.indirect.FormClient;
 import org.pac4j.jee.context.session.JEESessionStore;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SecurityHandlerTest {
 
@@ -29,11 +28,13 @@ public class SecurityHandlerTest {
     private final SecurityHandler handler = new SecurityHandler(config, "my-clients");
     private final HttpServletRequest req = mock(HttpServletRequest.class);
     private final HttpServletResponse res = mock(HttpServletResponse.class);
-    private final Context ctx = new Context(req, res, Collections.emptyMap());
+    private final Context ctx = mock(Context.class);
 
     @BeforeEach
     public void setCallbackLogic() {
         config.setSecurityLogic(securityLogic);
+        when(ctx.res()).thenReturn(res);
+        when(ctx.req()).thenReturn(req);
     }
 
     @Test

--- a/src/test/java/org/pac4j/javalin/example/JavalinPac4jExample.java
+++ b/src/test/java/org/pac4j/javalin/example/JavalinPac4jExample.java
@@ -2,6 +2,7 @@ package org.pac4j.javalin.example;
 
 import io.javalin.Javalin;
 import io.javalin.http.Context;
+import io.javalin.rendering.template.JavalinVelocity;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.exception.http.HttpAction;
@@ -26,7 +27,7 @@ import java.util.Optional;
 import static io.javalin.apibuilder.ApiBuilder.before;
 import static io.javalin.apibuilder.ApiBuilder.get;
 import static io.javalin.apibuilder.ApiBuilder.post;
-import static io.javalin.plugin.rendering.template.TemplateUtil.model;
+import static io.javalin.rendering.template.TemplateUtil.model;
 
 public class JavalinPac4jExample {
     private static final String JWT_SALT = "12345678901234567890123456789012";
@@ -38,6 +39,7 @@ public class JavalinPac4jExample {
         CallbackHandler callback = new CallbackHandler(config, null, true);
         SecurityHandler facebookSecurityHandler = new SecurityHandler(config, "FacebookClient", "", "excludedPath");
 
+        JavalinVelocity.init();
         Javalin.create()
                 .routes(() -> {
 
@@ -140,7 +142,7 @@ public class JavalinPac4jExample {
         if(client == null) throw new IllegalStateException("Client not found");
         FormClient formClient = (FormClient) client;
 
-        ctx.render("/templates/loginForm.vm", model("callbackUrl", formClient.getCallbackUrl()));
+        ctx.render("/templates/loginForm.vm", model("callbackUrl", formClient.getCallbackUrl() + "?client_name=FormClient"));
     }
 
     private static void protectedPage(Context ctx) {


### PR DESCRIPTION
Mainly adapted to newer versions and jakarta packages due to jetty upgrade.

In order to fix the `JavalinPac4jExample` class I had to add the client name as parameter as otherwise the CallbackLogic always used the OidcClient and returned and exception (as that was the first in the list). Not sure I am missing out on anything here, so any help appreciated.