### PR TITLE
Use javalin for params instead of servlet

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -3,4 +3,10 @@
         <Class name="org.pac4j.javalin.LogoutHandler"/>
         <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD" />
     </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/org/pac4j/framework/adapter/FrameworkAdapterImpl.java
+++ b/src/main/java/org/pac4j/framework/adapter/FrameworkAdapterImpl.java
@@ -1,0 +1,24 @@
+package org.pac4j.framework.adapter;
+
+import org.pac4j.core.adapter.DefaultFrameworkAdapter;
+import org.pac4j.core.config.Config;
+import org.pac4j.javalin.JavalinContextFactory;
+import org.pac4j.javalin.JavalinHttpActionAdapter;
+import org.pac4j.jee.context.session.JEESessionStoreFactory;
+
+public class FrameworkAdapterImpl extends DefaultFrameworkAdapter {
+
+    @Override
+    public void applyDefaultSettingsIfUndefined(final Config config) {
+        super.applyDefaultSettingsIfUndefined(config);
+
+        config.setWebContextFactoryIfUndefined(JavalinContextFactory.INSTANCE);
+        config.setSessionStoreFactoryIfUndefined(JEESessionStoreFactory.INSTANCE);
+        config.setHttpActionAdapterIfUndefined(JavalinHttpActionAdapter.INSTANCE);
+    }
+
+    @Override
+    public String toString() {
+        return "Javalin";
+    }
+}

--- a/src/main/java/org/pac4j/javalin/CallbackHandler.java
+++ b/src/main/java/org/pac4j/javalin/CallbackHandler.java
@@ -5,7 +5,6 @@ import io.javalin.http.Handler;
 import org.jetbrains.annotations.NotNull;
 import org.pac4j.core.adapter.FrameworkAdapter;
 import org.pac4j.core.config.Config;
-import org.pac4j.jee.context.JEEFrameworkParameters;
 
 import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
@@ -38,7 +37,7 @@ public class CallbackHandler implements Handler {
                 this.defaultUrl,
                 this.renewSession,
                 config.getClients().getClients().get(0).getName(),
-                new JEEFrameworkParameters(javalinCtx.req(), javalinCtx.res())
+                new JavalinFrameworkParameters(javalinCtx)
         );
 
     }

--- a/src/main/java/org/pac4j/javalin/JavalinContextFactory.java
+++ b/src/main/java/org/pac4j/javalin/JavalinContextFactory.java
@@ -4,6 +4,12 @@ import org.pac4j.core.context.FrameworkParameters;
 import org.pac4j.core.context.WebContextFactory;
 import org.pac4j.core.exception.TechnicalException;
 
+/**
+ * Build a Javalin context from parameters.
+ *
+ * @author Jacob Burroughs
+ * @since 7.0.0
+ */
 public class JavalinContextFactory implements WebContextFactory {
     /** Constant <code>INSTANCE</code> */
     public static final WebContextFactory INSTANCE = new JavalinContextFactory();

--- a/src/main/java/org/pac4j/javalin/JavalinContextFactory.java
+++ b/src/main/java/org/pac4j/javalin/JavalinContextFactory.java
@@ -1,0 +1,19 @@
+package org.pac4j.javalin;
+
+import org.pac4j.core.context.FrameworkParameters;
+import org.pac4j.core.context.WebContextFactory;
+import org.pac4j.core.exception.TechnicalException;
+
+public class JavalinContextFactory implements WebContextFactory {
+    /** Constant <code>INSTANCE</code> */
+    public static final WebContextFactory INSTANCE = new JavalinContextFactory();
+
+    /** {@inheritDoc} */
+    @Override
+    public JavalinWebContext newContext(final FrameworkParameters parameters) {
+        if (parameters instanceof JavalinFrameworkParameters jeeFrameworkParameters) {
+            return new JavalinWebContext(jeeFrameworkParameters.getContext());
+        }
+        throw new TechnicalException("Bad parameters type");
+    }
+}

--- a/src/main/java/org/pac4j/javalin/JavalinFrameworkParameters.java
+++ b/src/main/java/org/pac4j/javalin/JavalinFrameworkParameters.java
@@ -1,0 +1,12 @@
+package org.pac4j.javalin;
+
+import io.javalin.http.Context;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.pac4j.core.context.FrameworkParameters;
+
+@AllArgsConstructor
+@Getter
+public class JavalinFrameworkParameters implements FrameworkParameters {
+    private final Context context;
+}

--- a/src/main/java/org/pac4j/javalin/JavalinFrameworkParameters.java
+++ b/src/main/java/org/pac4j/javalin/JavalinFrameworkParameters.java
@@ -5,6 +5,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.pac4j.core.context.FrameworkParameters;
 
+/**
+ * Specific Javalin parameters.
+ *
+ * @author Jacob Burroughs
+ * @since 7.0.0
+ */
 @AllArgsConstructor
 @Getter
 public class JavalinFrameworkParameters implements FrameworkParameters {

--- a/src/main/java/org/pac4j/javalin/JavalinWebContext.java
+++ b/src/main/java/org/pac4j/javalin/JavalinWebContext.java
@@ -10,6 +10,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Web context that uses the Javalin implementations of parameter handling instead of the servlet ones
+ *
+ * @author Jacob Burroughs
+ * @since 7.0.0
+ */
 public class JavalinWebContext extends JEEContext {
     private final Context context;
 

--- a/src/main/java/org/pac4j/javalin/JavalinWebContext.java
+++ b/src/main/java/org/pac4j/javalin/JavalinWebContext.java
@@ -1,0 +1,43 @@
+package org.pac4j.javalin;
+
+import io.javalin.http.Context;
+import org.pac4j.jee.context.JEEContext;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JavalinWebContext extends JEEContext {
+    private final Context context;
+
+    public JavalinWebContext(final Context context) {
+        super(context.req(), context.res());
+
+        this.context = context;
+    }
+
+    public Context getContext() {
+        return context;
+    }
+
+    // We use our own implementation here because javalin does not use the servlet getParameter, and using the
+    // servlet getParameter method will consume the body and break javalin's formParams
+    @Override
+    public Optional<String> getRequestParameter(String name) {
+        return Optional.ofNullable(context.formParam(name)).or(() -> Optional.ofNullable(context.queryParam(name)));
+    }
+
+    @Override
+    public Map<String, String[]> getRequestParameters() {
+        Map<String, List<String>> allParams = new HashMap<>(context.formParamMap());
+        context.queryParamMap().forEach((k, v) -> allParams.merge(k, v, (v1, v2) ->
+                Stream.concat(v1.stream(), v2.stream()).toList()));
+        return allParams.entrySet().stream().collect(Collectors.toMap(
+            Map.Entry::getKey,
+            e -> e.getValue().toArray(new String[0])
+        ));
+    }
+}

--- a/src/main/java/org/pac4j/javalin/LogoutHandler.java
+++ b/src/main/java/org/pac4j/javalin/LogoutHandler.java
@@ -5,7 +5,6 @@ import io.javalin.http.Handler;
 import org.jetbrains.annotations.NotNull;
 import org.pac4j.core.adapter.FrameworkAdapter;
 import org.pac4j.core.config.Config;
-import org.pac4j.jee.context.JEEFrameworkParameters;
 
 import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
@@ -43,7 +42,7 @@ public class LogoutHandler implements Handler {
             this.localLogout,
             this.destroySession,
             this.centralLogout,
-            new JEEFrameworkParameters(javalinCtx.req(), javalinCtx.res())
+            new JavalinFrameworkParameters(javalinCtx)
         );
     }
 }

--- a/src/main/java/org/pac4j/javalin/SecurityHandler.java
+++ b/src/main/java/org/pac4j/javalin/SecurityHandler.java
@@ -3,6 +3,7 @@ package org.pac4j.javalin;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
 import io.javalin.http.servlet.JavalinServletContext;
+import io.javalin.http.servlet.Task;
 import org.jetbrains.annotations.NotNull;
 import org.pac4j.core.adapter.FrameworkAdapter;
 import org.pac4j.core.config.Config;
@@ -46,7 +47,8 @@ public class SecurityHandler implements Handler {
             new JavalinFrameworkParameters(javalinCtx)
         );
         if (result != AUTH_GRANTED) {
-            ((JavalinServletContext) javalinCtx).getTasks().clear(); // Used to throw UnauthorizedResponse
+            // Same logic javalin natively uses for skipping future tasks after a redirect in a before handler
+            ((JavalinServletContext) javalinCtx).getTasks().removeIf(Task::getSkipIfExceptionOccurred);
         }
     }
 }

--- a/src/main/java/org/pac4j/javalin/SecurityHandler.java
+++ b/src/main/java/org/pac4j/javalin/SecurityHandler.java
@@ -6,7 +6,6 @@ import io.javalin.http.servlet.JavalinServletContext;
 import org.jetbrains.annotations.NotNull;
 import org.pac4j.core.adapter.FrameworkAdapter;
 import org.pac4j.core.config.Config;
-import org.pac4j.jee.context.JEEFrameworkParameters;
 
 import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
@@ -44,7 +43,7 @@ public class SecurityHandler implements Handler {
             this.clients,
             this.authorizers,
             this.matchers,
-            new JEEFrameworkParameters(javalinCtx.req(), javalinCtx.res())
+            new JavalinFrameworkParameters(javalinCtx)
         );
         if (result != AUTH_GRANTED) {
             ((JavalinServletContext) javalinCtx).getTasks().clear(); // Used to throw UnauthorizedResponse

--- a/src/test/java/org/pac4j/javalin/JavalinHttpActionAdapterTest.java
+++ b/src/test/java/org/pac4j/javalin/JavalinHttpActionAdapterTest.java
@@ -1,10 +1,6 @@
 package org.pac4j.javalin;
 
-import io.javalin.http.BadRequestResponse;
-import io.javalin.http.Context;
-import io.javalin.http.ForbiddenResponse;
-import io.javalin.http.RedirectResponse;
-import io.javalin.http.UnauthorizedResponse;
+import io.javalin.http.*;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -31,12 +27,13 @@ class JavalinHttpActionAdapterTest {
     private final HttpServletRequest req = mock(HttpServletRequest.class);
     private final HttpServletResponse res = mock(HttpServletResponse.class);
     private final Context ctx = mock(Context.class);
-    private final JEEContext context = new JEEContext(req, res);
+    private JavalinWebContext context;
 
     @BeforeEach
     public void setupMocks() {
         when(ctx.res()).thenReturn(res);
         when(ctx.req()).thenReturn(req);
+        context = new JavalinWebContext(ctx);
     }
 
     @Test
@@ -53,25 +50,22 @@ class JavalinHttpActionAdapterTest {
 
     @Test
     public void testAdapterWithContentAction() throws IOException  {
-        ServletOutputStream sos = mock(ServletOutputStream.class);
-        when(res.getOutputStream()).thenReturn(sos);
 
         JavalinHttpActionAdapter.INSTANCE.adapt(new OkAction("my-content"), context);
 
-        verify(res).setStatus(eq(200));
-        ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
-        verify(sos).write(captor.capture());
-        byte[] value = captor.getValue();
-        assertThat(new String(value, StandardCharsets.UTF_8)).isEqualTo("my-content");
+        verify(ctx).status(eq(200));
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(ctx).result(captor.capture());
+        assertThat(captor.getValue()).isEqualTo("my-content");
     }
 
     @Test
     public void testAdapterWithLocationAction() {
-        assertThatThrownBy(() -> JavalinHttpActionAdapter.INSTANCE.adapt(new FoundAction("/redirect"), context))
-                .isExactlyInstanceOf(RedirectResponse.class);
+        JavalinHttpActionAdapter.INSTANCE.adapt(new FoundAction("/redirect"), context);
 
-        verify(res).setStatus(eq(302));
-        verify(res).setHeader(eq("Location"), eq("/redirect"));
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(ctx).redirect(captor.capture(), eq(HttpStatus.FOUND));
+        assertThat(captor.getValue()).isEqualTo("/redirect");
     }
 
     @Test
@@ -96,6 +90,6 @@ class JavalinHttpActionAdapterTest {
     public void testAdapterAnyOtherStatus() {
         JavalinHttpActionAdapter.INSTANCE.adapt(new HttpAction(123) {}, context);
 
-        verify(res).setStatus(eq(123));
+        verify(ctx).status(eq(123));
     }
 }

--- a/src/test/java/org/pac4j/javalin/JavalinHttpActionAdapterTest.java
+++ b/src/test/java/org/pac4j/javalin/JavalinHttpActionAdapterTest.java
@@ -1,7 +1,6 @@
 package org.pac4j.javalin;
 
 import io.javalin.http.*;
-import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,10 +12,8 @@ import org.pac4j.core.exception.http.FoundAction;
 import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.OkAction;
 import org.pac4j.core.exception.http.UnauthorizedAction;
-import org.pac4j.jee.context.JEEContext;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;

--- a/src/test/java/org/pac4j/javalin/LogoutHandlerTest.java
+++ b/src/test/java/org/pac4j/javalin/LogoutHandlerTest.java
@@ -10,7 +10,6 @@ import org.pac4j.core.config.Config;
 import org.pac4j.core.context.FrameworkParameters;
 import org.pac4j.core.engine.LogoutLogic;
 import org.pac4j.http.client.indirect.FormClient;
-import org.pac4j.jee.context.JEEFrameworkParameters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -117,10 +116,9 @@ public class LogoutHandlerTest {
         ArgumentCaptor<FrameworkParameters> captor = ArgumentCaptor.forClass(FrameworkParameters.class);
         verify(logoutLogic).perform(any(), any(), any(), any(), any(), any(), captor.capture());
         FrameworkParameters parameters = captor.getValue();
-        assertThat(parameters).isExactlyInstanceOf(JEEFrameworkParameters.class);
+        assertThat(parameters).isExactlyInstanceOf(JavalinFrameworkParameters.class);
 
-        JEEFrameworkParameters jeeFrameworkParameters = (JEEFrameworkParameters) parameters;
-        assertThat(jeeFrameworkParameters.getRequest()).isSameAs(req);
-        assertThat(jeeFrameworkParameters.getResponse()).isSameAs(res);
+        JavalinFrameworkParameters javalinFrameworkParameters = (JavalinFrameworkParameters) parameters;
+        assertThat(javalinFrameworkParameters.getContext()).isSameAs(ctx);
     }
 }

--- a/src/test/java/org/pac4j/javalin/SecurityHandlerTest.java
+++ b/src/test/java/org/pac4j/javalin/SecurityHandlerTest.java
@@ -65,6 +65,6 @@ public class SecurityHandlerTest {
         handler.handle(ctx);
 
         verify(ctx).getTasks();
-        verify(deque).clear();
+        verify(deque).removeIf(any());
     }
 }

--- a/src/test/java/org/pac4j/javalin/example/ExampleConfigFactory.java
+++ b/src/test/java/org/pac4j/javalin/example/ExampleConfigFactory.java
@@ -19,7 +19,6 @@ import org.pac4j.http.client.direct.ParameterClient;
 import org.pac4j.http.client.indirect.FormClient;
 import org.pac4j.http.client.indirect.IndirectBasicAuthClient;
 import org.pac4j.javalin.JavalinContextFactory;
-import org.pac4j.jee.context.JEEContextFactory;
 import org.pac4j.jee.context.session.JEESessionStoreFactory;
 import org.pac4j.jwt.config.signature.SecretSignatureConfiguration;
 import org.pac4j.jwt.credentials.authenticator.JwtAuthenticator;

--- a/src/test/java/org/pac4j/javalin/example/ExampleConfigFactory.java
+++ b/src/test/java/org/pac4j/javalin/example/ExampleConfigFactory.java
@@ -18,6 +18,7 @@ import org.pac4j.http.client.direct.HeaderClient;
 import org.pac4j.http.client.direct.ParameterClient;
 import org.pac4j.http.client.indirect.FormClient;
 import org.pac4j.http.client.indirect.IndirectBasicAuthClient;
+import org.pac4j.javalin.JavalinContextFactory;
 import org.pac4j.jee.context.JEEContextFactory;
 import org.pac4j.jee.context.session.JEESessionStoreFactory;
 import org.pac4j.jwt.config.signature.SecretSignatureConfiguration;
@@ -113,7 +114,7 @@ public class ExampleConfigFactory implements ConfigFactory {
         config.addAuthorizer("custom", new CustomAuthorizer());
         config.addMatcher("excludedPath", new PathMatcher().excludeRegex("^/facebook/notprotected$"));
         config.setHttpActionAdapter(new ExampleHttpActionAdapter());
-        config.setWebContextFactory(JEEContextFactory.INSTANCE);
+        config.setWebContextFactory(JavalinContextFactory.INSTANCE);
         config.setSessionStoreFactory(JEESessionStoreFactory.INSTANCE);
         config.setProfileManagerFactory(ProfileManagerFactory.DEFAULT);
         return config;

--- a/src/test/java/org/pac4j/javalin/example/JavalinPac4jExample.java
+++ b/src/test/java/org/pac4j/javalin/example/JavalinPac4jExample.java
@@ -13,7 +13,6 @@ import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.http.client.indirect.FormClient;
 import org.pac4j.javalin.*;
-import org.pac4j.jee.context.JEEContext;
 import org.pac4j.jee.context.session.JEESessionStore;
 import org.pac4j.jwt.config.signature.SecretSignatureConfiguration;
 import org.pac4j.jwt.profile.JwtGenerator;

--- a/src/test/java/org/pac4j/javalin/example/JavalinPac4jExample.java
+++ b/src/test/java/org/pac4j/javalin/example/JavalinPac4jExample.java
@@ -12,12 +12,8 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.http.client.indirect.FormClient;
-import org.pac4j.javalin.CallbackHandler;
-import org.pac4j.javalin.JavalinHttpActionAdapter;
-import org.pac4j.javalin.LogoutHandler;
-import org.pac4j.javalin.SecurityHandler;
+import org.pac4j.javalin.*;
 import org.pac4j.jee.context.JEEContext;
-import org.pac4j.jee.context.JEEFrameworkParameters;
 import org.pac4j.jee.context.session.JEESessionStore;
 import org.pac4j.jwt.config.signature.SecretSignatureConfiguration;
 import org.pac4j.jwt.profile.JwtGenerator;
@@ -126,7 +122,7 @@ public class JavalinPac4jExample {
     }
 
     private static void jwt(Context ctx) {
-        ProfileManager manager = new ProfileManager(new JEEContext(ctx.req(), ctx.res()), new JEESessionStore());
+        ProfileManager manager = new ProfileManager(new JavalinWebContext(ctx), new JEESessionStore());
         Optional<CommonProfile> profile = manager.getProfile(CommonProfile.class);
         String token = "";
         if (profile.isPresent()) {
@@ -149,7 +145,7 @@ public class JavalinPac4jExample {
     }
 
     private static List<UserProfile> getProfiles(Context ctx, Config config) {
-        JEEFrameworkParameters parameters = new JEEFrameworkParameters(ctx.req(), ctx.res());
+        JavalinFrameworkParameters parameters = new JavalinFrameworkParameters(ctx);
         return config.getProfileManagerFactory().apply(
                 config.getWebContextFactory().newContext(parameters),
                 config.getSessionStoreFactory().newSessionStore(parameters)
@@ -157,7 +153,7 @@ public class JavalinPac4jExample {
     }
 
     private static void forceLogin(Context ctx, Config config) {
-        WebContext context = config.getWebContextFactory().newContext(new JEEFrameworkParameters(ctx.req(), ctx.res()));
+        WebContext context = config.getWebContextFactory().newContext(new JavalinFrameworkParameters(ctx));
         String clientName = context.getRequestParameter("FormClient").orElse(null);
         if(clientName == null) throw new IllegalStateException("Client name not found");
 


### PR DESCRIPTION
Ensures that javalin apps can still use getFormParams
when using pac4j

fixes https://github.com/pac4j/javalin-pac4j/issues/29
